### PR TITLE
Git branch versioning option

### DIFF
--- a/addons/AutoExportVersion/AutoExportVersion.gd
+++ b/addons/AutoExportVersion/AutoExportVersion.gd
@@ -23,7 +23,7 @@ func _fetch_version(features: PoolStringArray, is_debug: bool, path: String, fla
 	### Git branch version ### --------------------------------------------------------------------
 	
 	# Version is the current branch name, useful for feature branches like 'release-1.0.0'
-	# Requires git installed and project inside git repository with at least 1 commit.
+	# Requires git installed and project inside git repository.
 
 #	var output := []
 #	OS.execute("git", PoolStringArray(["rev-parse", "--abbrev-ref", "HEAD"]), true, output)

--- a/addons/AutoExportVersion/AutoExportVersion.gd
+++ b/addons/AutoExportVersion/AutoExportVersion.gd
@@ -19,6 +19,18 @@ func _fetch_version(features: PoolStringArray, is_debug: bool, path: String, fla
 #		push_error("Failed to fetch version. Make sure you have git installed and project is inside valid git directory.")
 #	else:
 #		return output[0].trim_suffix("\n")
+
+	### Git branch version ### --------------------------------------------------------------------
+	
+	# Version is the current branch name, useful for feature branches like 'release-1.0.0'
+	# Requires git installed and project inside git repository with at least 1 commit.
+
+#	var output := []
+#	OS.execute("git", PoolStringArray(["rev-parse", "--abbrev-ref", "HEAD"]), true, output)
+#	if output.empty() or output[0].empty():
+#		push_error("Failed to fetch version. Make sure you have git installed and project is inside valid git directory.")
+#	else:
+#		return output[0].trim_suffix("\n")
 	
 	### Profile version ### -----------------------------------------------------------------------
 	

--- a/addons/AutoExportVersion/AutoExportVersion.gd
+++ b/addons/AutoExportVersion/AutoExportVersion.gd
@@ -22,7 +22,7 @@ func _fetch_version(features: PoolStringArray, is_debug: bool, path: String, fla
 
 	### Git branch version ### --------------------------------------------------------------------
 	
-	# Version is the current branch name, useful for feature branches like 'release-1.0.0'
+	# Version is the current branch name. Useful for feature branches like 'release-1.0.0'
 	# Requires git installed and project inside git repository.
 
 #	var output := []


### PR DESCRIPTION
First just wanted to say thanks for making this plugin! For my needs I to modified it to save both branch version and number of commits. I'd like to contribute back this small change in case other might have use for it as well :)

This pull request gives the option for users to store the current git branch name as the current version.

This is particularly useful to users who manage versioning by creating release branches.